### PR TITLE
[Work in progress] Classpath issue when trying Google Pubsub on Local docker env

### DIFF
--- a/docker/compose/docker-compose_hadoop284_hive233_spark244.yml
+++ b/docker/compose/docker-compose_hadoop284_hive233_spark244.yml
@@ -181,73 +181,73 @@ services:
       - KAFKA_ZOOKEEPER_CONNECT=zookeeper:2181
       - ALLOW_PLAINTEXT_LISTENER=yes
 
-  presto-coordinator-1:
-    container_name: presto-coordinator-1
-    hostname: presto-coordinator-1
-    image: apachehudi/hudi-hadoop_2.8.4-prestobase_0.271:latest
-    ports:
-      - '8090:8090'
-    environment:
-      - PRESTO_JVM_MAX_HEAP=512M
-      - PRESTO_QUERY_MAX_MEMORY=1GB
-      - PRESTO_QUERY_MAX_MEMORY_PER_NODE=256MB
-      - PRESTO_QUERY_MAX_TOTAL_MEMORY_PER_NODE=384MB
-      - PRESTO_MEMORY_HEAP_HEADROOM_PER_NODE=100MB
-      - TERM=xterm
-    links:
-      - "hivemetastore"
-    volumes:
-      - ${HUDI_WS}:/var/hoodie/ws
-    command: coordinator
+        #presto-coordinator-1:
+        #container_name: presto-coordinator-1
+        #hostname: presto-coordinator-1
+        #image: apachehudi/hudi-hadoop_2.8.4-prestobase_0.271:latest
+        #ports:
+        #- '8090:8090'
+        #environment:
+        #- PRESTO_JVM_MAX_HEAP=512M
+        #- PRESTO_QUERY_MAX_MEMORY=1GB
+        #- PRESTO_QUERY_MAX_MEMORY_PER_NODE=256MB
+        #- PRESTO_QUERY_MAX_TOTAL_MEMORY_PER_NODE=384MB
+        #- PRESTO_MEMORY_HEAP_HEADROOM_PER_NODE=100MB
+        #- TERM=xterm
+        #links:
+        #- "hivemetastore"
+        #volumes:
+        #- ${HUDI_WS}:/var/hoodie/ws
+        #command: coordinator
 
-  presto-worker-1:
-    container_name: presto-worker-1
-    hostname: presto-worker-1
-    image: apachehudi/hudi-hadoop_2.8.4-prestobase_0.271:latest
-    depends_on: [ "presto-coordinator-1" ]
-    environment:
-      - PRESTO_JVM_MAX_HEAP=512M
-      - PRESTO_QUERY_MAX_MEMORY=1GB
-      - PRESTO_QUERY_MAX_MEMORY_PER_NODE=256MB
-      - PRESTO_QUERY_MAX_TOTAL_MEMORY_PER_NODE=384MB
-      - PRESTO_MEMORY_HEAP_HEADROOM_PER_NODE=100MB
-      - TERM=xterm
-    links:
-      - "hivemetastore"
-      - "hiveserver"
-      - "hive-metastore-postgresql"
-      - "namenode"
-    volumes:
-      - ${HUDI_WS}:/var/hoodie/ws
-    command: worker
+        #presto-worker-1:
+    #container_name: presto-worker-1
+    #hostname: presto-worker-1
+    #image: apachehudi/hudi-hadoop_2.8.4-prestobase_0.271:latest
+    #depends_on: [ "presto-coordinator-1" ]
+    #environment:
+    #- PRESTO_JVM_MAX_HEAP=512M
+    #- PRESTO_QUERY_MAX_MEMORY=1GB
+    #- PRESTO_QUERY_MAX_MEMORY_PER_NODE=256MB
+    #- PRESTO_QUERY_MAX_TOTAL_MEMORY_PER_NODE=384MB
+    #- PRESTO_MEMORY_HEAP_HEADROOM_PER_NODE=100MB
+    #- TERM=xterm
+    #links:
+    #- "hivemetastore"
+    #- "hiveserver"
+    #- "hive-metastore-postgresql"
+    #- "namenode"
+    #volumes:
+    #- ${HUDI_WS}:/var/hoodie/ws
+    #command: worker
 
-  trino-coordinator-1:
-    container_name: trino-coordinator-1
-    hostname: trino-coordinator-1
-    image: apachehudi/hudi-hadoop_2.8.4-trinocoordinator_368:latest
-    ports:
-      - '8091:8091'
-    links:
-      - "hivemetastore"
-    volumes:
-      - ${HUDI_WS}:/var/hoodie/ws
-    command: http://trino-coordinator-1:8091 trino-coordinator-1
+    #    trino-coordinator-1:
+    #container_name: trino-coordinator-1
+    #hostname: trino-coordinator-1
+    #image: apachehudi/hudi-hadoop_2.8.4-trinocoordinator_368:latest
+    #ports:
+    #- '8091:8091'
+    #links:
+    #- "hivemetastore"
+    #volumes:
+    #- ${HUDI_WS}:/var/hoodie/ws
+    #command: http://trino-coordinator-1:8091 trino-coordinator-1
 
-  trino-worker-1:
-    container_name: trino-worker-1
-    hostname: trino-worker-1
-    image: apachehudi/hudi-hadoop_2.8.4-trinoworker_368:latest
-    depends_on: [ "trino-coordinator-1" ]
-    ports:
-      - '8092:8092'
-    links:
-      - "hivemetastore"
-      - "hiveserver"
-      - "hive-metastore-postgresql"
-      - "namenode"
-    volumes:
-      - ${HUDI_WS}:/var/hoodie/ws
-    command: http://trino-coordinator-1:8091 trino-worker-1
+    #trino-worker-1:
+    #container_name: trino-worker-1
+    #hostname: trino-worker-1
+    #image: apachehudi/hudi-hadoop_2.8.4-trinoworker_368:latest
+    #depends_on: [ "trino-coordinator-1" ]
+    #ports:
+    #- '8092:8092'
+    #links:
+    #- "hivemetastore"
+    #- "hiveserver"
+    #- "hive-metastore-postgresql"
+    #- "namenode"
+    #volumes:
+    #- ${HUDI_WS}:/var/hoodie/ws
+    #command: http://trino-coordinator-1:8091 trino-worker-1
 
   graphite:
     container_name: graphite
@@ -275,10 +275,12 @@ services:
       - "hiveserver"
       - "hive-metastore-postgresql"
       - "namenode"
-      - "presto-coordinator-1"
-      - "trino-coordinator-1"
+        #- "presto-coordinator-1"
+        #- "trino-coordinator-1"
     volumes:
       - ${HUDI_WS}:/var/hoodie/ws
+        # pramod
+      - ~/.config/gcloud:/root/.config/gcloud
 
   adhoc-2:
     image: apachehudi/hudi-hadoop_2.8.4-hive_2.3.3-sparkadhoc_2.4.4:latest
@@ -295,10 +297,12 @@ services:
       - "hiveserver"
       - "hive-metastore-postgresql"
       - "namenode"
-      - "presto-coordinator-1"
-      - "trino-coordinator-1"
+        #- "presto-coordinator-1"
+        #- "trino-coordinator-1"
     volumes:
       - ${HUDI_WS}:/var/hoodie/ws
+        # pramod
+      - ~/.config/gcloud:/root/.config/gcloud
 
 volumes:
   namenode:

--- a/docker/setup_demo.sh
+++ b/docker/setup_demo.sh
@@ -25,9 +25,14 @@ if [ "$HUDI_DEMO_ENV" != "dev" ]; then
   echo "Pulling docker demo images ..."
   HUDI_WS=${WS_ROOT} docker-compose -f ${SCRIPT_PATH}/compose/docker-compose_hadoop284_hive233_spark244.yml pull
 fi
-sleep 5
+
+# pramod
+#sleep 5
+sleep 30
 HUDI_WS=${WS_ROOT} docker-compose -f ${SCRIPT_PATH}/compose/docker-compose_hadoop284_hive233_spark244.yml up -d
-sleep 15
+# pramod
+#sleep 15
+sleep 120
 
 docker exec -it adhoc-1 /bin/bash /var/hoodie/ws/docker/demo/setup_demo_container.sh
 docker exec -it adhoc-2 /bin/bash /var/hoodie/ws/docker/demo/setup_demo_container.sh

--- a/hudi-utilities/pom.xml
+++ b/hudi-utilities/pom.xml
@@ -60,6 +60,10 @@
         <groupId>org.apache.rat</groupId>
         <artifactId>apache-rat-plugin</artifactId>
       </plugin>
+
+      <!-- Temp hack to be able to exec a single Java class in multi-module maven project.
+      Ref: https://stackoverflow.com/a/26448447/700045running-a-specific-maven-plugin-goal-from-the-command-line-in-a-sub-module-of-a/26448447#26448447
+      -->
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>

--- a/hudi-utilities/pom.xml
+++ b/hudi-utilities/pom.xml
@@ -60,6 +60,13 @@
         <groupId>org.apache.rat</groupId>
         <artifactId>apache-rat-plugin</artifactId>
       </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <configuration>
+          <skip>false</skip>
+        </configuration>
+      </plugin>
     </plugins>
 
     <resources>
@@ -381,6 +388,12 @@
       <groupId>${hive.groupid}</groupId>
       <artifactId>hive-service</artifactId>
       <version>${hive.version}</version>
+    </dependency>
+
+    <!-- Google Cloud Platform (GCP) -->
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-pubsub</artifactId>
     </dependency>
 
     <!-- Hoodie - Test -->

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/PubsubEventsSource.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/PubsubEventsSource.java
@@ -1,0 +1,45 @@
+package org.apache.hudi.utilities.sources;
+
+import com.google.cloud.pubsub.v1.AckReplyConsumer;
+import com.google.cloud.pubsub.v1.MessageReceiver;
+import com.google.cloud.pubsub.v1.Subscriber;
+import com.google.pubsub.v1.ProjectSubscriptionName;
+import com.google.pubsub.v1.PubsubMessage;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+public class PubsubEventsSource {
+
+        public static void main(String... args) throws Exception {
+            String projectId = "infra-dev-358110";
+            String subscriptionId = "gcs-obj-1-sub";
+            subscribeAsyncExample(projectId, subscriptionId);
+        }
+
+        public static void subscribeAsyncExample(String projectId, String subscriptionId) {
+            ProjectSubscriptionName subscriptionName =
+                    ProjectSubscriptionName.of(projectId, subscriptionId);
+
+            // Instantiate an asynchronous message receiver.
+            MessageReceiver receiver =
+                    (PubsubMessage message, AckReplyConsumer consumer) -> {
+                        // Handle incoming message, then ack the received message.
+                        System.out.println("message id: " + message.getMessageId());
+                        System.out.println("message data: " + message.getData().toStringUtf8());
+//                        consumer.ack();
+                    };
+
+            Subscriber subscriber = null;
+            try {
+                subscriber = Subscriber.newBuilder(subscriptionName, receiver).build();
+                // Start the subscriber.
+                subscriber.startAsync().awaitRunning();
+                System.out.printf("Listening for messages on %s:\n", subscriptionName.toString());
+                // Allow the subscriber to run for 30s unless an unrecoverable error occurs.
+                subscriber.awaitTerminated(30, TimeUnit.MINUTES);
+            } catch (TimeoutException timeoutException) {
+                // Shut down the subscriber after 30s. Stop receiving messages.
+                subscriber.stopAsync();
+            }
+        }
+}

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/PubsubEventsSource.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/PubsubEventsSource.java
@@ -11,8 +11,8 @@ import java.util.concurrent.TimeoutException;
 public class PubsubEventsSource {
 
         public static void main(String... args) throws Exception {
-            String projectId = "infra-dev-358110";
-            String subscriptionId = "gcs-obj-1-sub";
+            String projectId = "redacted";
+            String subscriptionId = "redacted";
             subscribeAsyncExample(projectId, subscriptionId);
         }
 

--- a/packaging/hudi-utilities-bundle/pom.xml
+++ b/packaging/hudi-utilities-bundle/pom.xml
@@ -165,6 +165,56 @@
                   <include>org.apache.curator:curator-recipes</include>
                   <include>commons-codec:commons-codec</include>
                   <include>commons-io:commons-io</include>
+
+	          <!-- pramod -->
+                        <include>com.google.cloud:google-cloud-pubsub</include>
+                        <include>com.google.api.grpc:proto-google-cloud-pubsub-v1</include>
+			<include>io.grpc:grpc-api</include>
+			<include>io.grpc:grpc-context</include>
+			<include>io.grpc:grpc-stub</include>
+			<include>io.grpc:grpc-protobuf</include>
+			<include>io.grpc:grpc-protobuf-lite</include>
+			<include>com.google.api:api-common</include>
+			<include>javax.annotation:javax.annotation-api</include>
+			<include>com.google.api.grpc:proto-google-common-protos</include>
+			<include>com.google.auth:google-auth-library-oauth2-http</include>
+			<include>com.google.auth:google-auth-library-credentials</include>
+			<include>com.google.http-client:google-http-client-gson</include>
+			<include>com.google.api.grpc:proto-google-cloud-pubsub-v1</include>
+			<include>com.google.api.grpc:proto-google-iam-v1</include>
+			<include>com.google.guava:failureaccess</include>
+			<include>com.google.guava:listenablefuture</include>
+			<include>org.checkerframework:checker-qual</include>
+			<include>com.google.j2objc:j2objc-annotations</include>
+			<include>com.google.api:gax</include>
+			<include>com.google.api:gax-grpc</include>
+			<include>io.grpc:grpc-alts</include>
+			<include>io.grpc:grpc-grpclb</include>
+			<include>org.conscrypt:conscrypt-openjdk-uber</include>
+			<include>io.grpc:grpc-auth</include>
+			<include>io.grpc:grpc-netty-shaded</include>
+			<include>io.grpc:grpc-googleapis</include>
+			<include>io.grpc:grpc-xds</include>
+			<include>io.grpc:grpc-services</include>
+			<include>com.google.re2j:re2j</include>
+			<include>io.opencensus:opencensus-proto</include>
+			<include>com.google.api:gax-httpjson</include>
+			<include>com.google.protobuf:protobuf-java-util</include>
+			<include>org.threeten:threetenbp</include>
+			<include>io.opencensus:opencensus-api</include>
+			<include>io.grpc:grpc-core</include>
+			<include>com.google.android:annotations</include>
+			<include>org.codehaus.mojo:animal-sniffer-annotations</include>
+			<include>io.perfmark:perfmark-api</include>
+			<include>com.google.errorprone:error_prone_annotations</include>
+			<include>com.google.auto.value:auto-value-annotations</include>
+			<include>com.google.http-client:google-http-client</include>
+			<include>io.opencensus:opencensus-contrib-http-util</include>
+
+			<!-- Also adding -->
+			<include>com.google.protobuf:protobuf-java</include>
+			<include>com.google.guava:guava</include>
+			  
                 </includes>
               </artifactSet>
               <relocations>
@@ -462,6 +512,17 @@
       <artifactId>curator-recipes</artifactId>
       <version>${zk-curator.version}</version>
     </dependency>
+
+  <!-- pramod : Following template in trino and presto -->
+    <!--Guava needs to be shaded because HBase 1.2.3 depends on an earlier guava version i.e 12.0.1 and hits runtime
+    issues with the guava version present in utilities runtime-->
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>12.0.1</version>
+      <scope>provided</scope>
+    </dependency>	  
+
   </dependencies>
 
   <profiles>

--- a/packaging/hudi-utilities-bundle/pom.xml
+++ b/packaging/hudi-utilities-bundle/pom.xml
@@ -168,8 +168,8 @@
 
 	          <!-- pramod: Adding cloud pubsub and its dependencies manually to be included for Shading.
 	           In an attempt to get this working on local docker env -->
-                        <include>com.google.cloud:google-cloud-pubsub</include>
-                        <include>com.google.api.grpc:proto-google-cloud-pubsub-v1</include>
+            <include>com.google.cloud:google-cloud-pubsub</include>
+            <include>com.google.api.grpc:proto-google-cloud-pubsub-v1</include>
 			<include>io.grpc:grpc-api</include>
 			<include>io.grpc:grpc-context</include>
 			<include>io.grpc:grpc-stub</include>
@@ -360,6 +360,18 @@
                   <shadedPattern>org.apache.hudi.org.apache.hadoop.metrics2.util.MetricSampleQuantiles
                   </shadedPattern>
                 </relocation>
+
+                <!-- start pramod -->
+                <relocation>
+                  <pattern>com.google.common.base.</pattern>
+                  <shadedPattern>org.apache.hudibundle.com.google.common.base.</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>com.google.api.</pattern>
+                  <shadedPattern>org.apache.hudibundle.com.google.api.</shadedPattern>
+                </relocation>
+                <!-- end pramod -->
+
               </relocations>
               <filters>
                 <filter>
@@ -513,15 +525,20 @@
       <version>${zk-curator.version}</version>
     </dependency>
 
-  <!-- pramod : Following template in trino and presto -->
+  <!-- start pramod : Following template in trino and presto -->
     <!--Guava needs to be shaded because HBase 1.2.3 depends on an earlier guava version i.e 12.0.1 and hits runtime
     issues with the guava version present in utilities runtime-->
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>12.0.1</version>
-      <scope>provided</scope>
-    </dependency>	  
+      <version>31.1-jre</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.api</groupId>
+      <artifactId>api-common</artifactId>
+      <version>2.2.1</version>
+    </dependency>
+    <!-- end pramod -->
 
   </dependencies>
 

--- a/packaging/hudi-utilities-bundle/pom.xml
+++ b/packaging/hudi-utilities-bundle/pom.xml
@@ -370,6 +370,10 @@
                   <pattern>com.google.api.</pattern>
                   <shadedPattern>org.apache.hudibundle.com.google.api.</shadedPattern>
                 </relocation>
+                <relocation>
+                  <pattern>com.google.common.</pattern>
+                  <shadedPattern>org.apache.hudibundle.com.google.common.</shadedPattern>
+                </relocation>
                 <!-- end pramod -->
 
               </relocations>
@@ -531,16 +535,32 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>31.1-jre</version>
+<!--      <version>31.1-jre</version>-->
     </dependency>
     <dependency>
       <groupId>com.google.api</groupId>
       <artifactId>api-common</artifactId>
-      <version>2.2.1</version>
     </dependency>
     <!-- end pramod -->
 
   </dependencies>
+
+  <!--start pramod -->
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.google.guava</groupId>
+        <artifactId>guava</artifactId>
+        <version>31.1-jre</version>
+      </dependency>
+    <dependency>
+      <groupId>com.google.api</groupId>
+      <artifactId>api-common</artifactId>
+      <version>2.2.1</version>
+    </dependency>	      
+    </dependencies>
+  </dependencyManagement>
+  <!-- end pramod -->	  
 
   <profiles>
     <profile>

--- a/packaging/hudi-utilities-bundle/pom.xml
+++ b/packaging/hudi-utilities-bundle/pom.xml
@@ -166,7 +166,8 @@
                   <include>commons-codec:commons-codec</include>
                   <include>commons-io:commons-io</include>
 
-	          <!-- pramod -->
+	          <!-- pramod: Adding cloud pubsub and its dependencies manually to be included for Shading.
+	           In an attempt to get this working on local docker env -->
                         <include>com.google.cloud:google-cloud-pubsub</include>
                         <include>com.google.api.grpc:proto-google-cloud-pubsub-v1</include>
 			<include>io.grpc:grpc-api</include>
@@ -210,7 +211,6 @@
 			<include>com.google.auto.value:auto-value-annotations</include>
 			<include>com.google.http-client:google-http-client</include>
 			<include>io.opencensus:opencensus-contrib-http-util</include>
-
 			<!-- Also adding -->
 			<include>com.google.protobuf:protobuf-java</include>
 			<include>com.google.guava:guava</include>

--- a/pom.xml
+++ b/pom.xml
@@ -48,11 +48,11 @@
     <module>packaging/hudi-datahub-sync-bundle</module>
     <module>packaging/hudi-hive-sync-bundle</module>
     <module>packaging/hudi-spark-bundle</module>
-    <module>packaging/hudi-presto-bundle</module>
+	    <!--<module>packaging/hudi-presto-bundle</module> -->
     <module>packaging/hudi-utilities-bundle</module>
     <module>packaging/hudi-utilities-slim-bundle</module>
     <module>packaging/hudi-timeline-server-bundle</module>
-    <module>packaging/hudi-trino-bundle</module>
+	    <!-- <module>packaging/hudi-trino-bundle</module> -->
     <module>hudi-examples</module>
     <module>hudi-flink-datasource</module>
     <module>hudi-kafka-connect</module>
@@ -490,6 +490,16 @@
               </goals>
             </execution>
           </executions>
+        </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>exec-maven-plugin</artifactId>
+          <version>1.3.2</version>
+          <configuration>
+            <skip>true</skip>
+<!--            <mainClass>none</mainClass>-->
+            <executable>java</executable>
+          </configuration>
         </plugin>
       </plugins>
     </pluginManagement>
@@ -1146,6 +1156,14 @@
         <artifactId>log4j-core</artifactId>
         <version>${log4j.test.version}</version>
         <scope>test</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>com.google.cloud</groupId>
+        <artifactId>libraries-bom</artifactId>
+        <version>26.0.0</version>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
 
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -48,10 +48,12 @@
     <module>packaging/hudi-datahub-sync-bundle</module>
     <module>packaging/hudi-hive-sync-bundle</module>
     <module>packaging/hudi-spark-bundle</module>
+    <!-- Commented in an attempt to get around Guava Preconditions.checkArguments method conflict -->
 	    <!--<module>packaging/hudi-presto-bundle</module> -->
     <module>packaging/hudi-utilities-bundle</module>
     <module>packaging/hudi-utilities-slim-bundle</module>
     <module>packaging/hudi-timeline-server-bundle</module>
+    <!-- Commented in an attempt to get around Guava Preconditions.checkArguments method conflict -->
 	    <!-- <module>packaging/hudi-trino-bundle</module> -->
     <module>hudi-examples</module>
     <module>hudi-flink-datasource</module>
@@ -491,6 +493,10 @@
             </execution>
           </executions>
         </plugin>
+
+        <!-- Temp hack to be able to exec a single Java class in multi-module maven project.
+        Ref: https://stackoverflow.com/a/26448447/700045running-a-specific-maven-plugin-goal-from-the-command-line-in-a-sub-module-of-a/26448447#26448447
+        -->
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>exec-maven-plugin</artifactId>


### PR DESCRIPTION
I'm stuck trying to run my code changes in Hudi's local docker environment. The code is getting picked up correctly but there is a method conflict with Preconditions.checkArgument. Below is the full stack trace:
```
root@adhoc-2:/opt# spark-submit --class org.apache.hudi.utilities.sources.PubsubEventsSource $HUDI_UTILITIES_BUNDLE

22/08/03 11:55:32 WARN NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable
Exception in thread "main" java.lang.NoSuchMethodError: com.google.common.base.Preconditions.checkArgument(ZLjava/lang/String;J)V
        at com.google.api.gax.batching.BlockingSemaphore.checkNotNegative(BlockingSemaphore.java:41)
        at com.google.api.gax.batching.BlockingSemaphore.<init>(BlockingSemaphore.java:45)
        at com.google.api.gax.batching.FlowController.<init>(FlowController.java:189)
        at com.google.api.gax.batching.FlowController.<init>(FlowController.java:158)
        at com.google.cloud.pubsub.v1.Subscriber.<init>(Subscriber.java:169)
        at com.google.cloud.pubsub.v1.Subscriber.<init>(Subscriber.java:91)
```

I'm aiming to replicate the Step #2 of the [Building Local Docker Containers](https://hudi.apache.org/docs/docker_demo/#building-local-docker-containers) from the Hudi docs, which says the Jars can be picked up locally via the $HUDI_WS variable. 

I'm currently suspecting issues with Guava pulled in for Presto and Trino, and trying to comment Presto and Trino modules before running the following command: 
```$ mvn clean package -Pintegration-tests -DskipTests -Dcheckstyle.skip -Drat.skip=true```

I've also tweaked the POM of the packaging/hudi-utilities-bundle to manually include a bunch of Google Pubsub related Jars while generating the Shaded jar.

Related Slack thread: https://onehouseinc.slack.com/archives/C022Z7ZAC95/p1659541874159959